### PR TITLE
update PurchaseResponse to the v2 and adapt the DigestTest to contain…

### DIFF
--- a/src/Messages/PurchaseResponse.php
+++ b/src/Messages/PurchaseResponse.php
@@ -10,6 +10,7 @@ class PurchaseResponse extends AbstractResponse implements RedirectResponseInter
 {
     const TEST_ENDPOINT = 'https://euro.test.modirum.com/vpos/shophandlermpi';
     const LIVE_ENDPOINT = 'https://vpos.eurocommerce.gr/vpos/shophandlermpi';
+    const VERSION = 2;
 
     public function isSuccessful()
     {
@@ -46,9 +47,11 @@ class PurchaseResponse extends AbstractResponse implements RedirectResponseInter
          */
         $request = $this->getRequest();
         $data = [
+            'version' => self::VERSION,
             'mid' => $request->getMerchantId(),
             'lang' => $request->getLanguage(),
             'orderid' => $request->getTransactionId(),
+            'orderDesc' =>  $request->getTransactionId(),
             'orderAmount' => $request->getAmount(),
             'currency' => $request->getCurrency(),
             'payerEmail' => $request->getCard()->getEmail(),

--- a/src/lib/DigestCalculator.php
+++ b/src/lib/DigestCalculator.php
@@ -12,7 +12,6 @@ class DigestCalculator
 
         // Now take all the data values, join them together, append the shared secret, encode the result and that's
         // the digest!
-
         return base64_encode(
             hash(
                 'sha256',

--- a/tests/Omnipay/Cardlink/DigestTest.php
+++ b/tests/Omnipay/Cardlink/DigestTest.php
@@ -3,25 +3,39 @@
 namespace Omnipay\Cardlink;
 
 use DigiTickets\Cardlink\lib\DigestCalculator;
-use Omnipay\Common\CreditCard;
 use Omnipay\Tests\TestCase;
 
 class DigestTest extends TestCase
 {
+    const SECRET_KEY = 'Cardlink1';
+
     public function testDigest()
     {
         $data = [
-            'one' => 'one',
-            'two' => 'two'
+            'version' => 2,
+            'mid' => '0101119349',
+            'lang' => 'en',
+            'deviceCategory' => '0',
+            'orderid' => 'O170911143656',
+            'orderDesc' => 'Test order some items',
+            'orderAmount' => '0.12',
+            'currency' => 'EUR',
+            'payerEmail' => 'cardlink@cardlink.gr',
+            'payerPhone' => '6900000000',
+            'element' => 'GRUK',
+            'payMethod' => 'visa',
+            'confirmUrl' => 'https://euro.test.modirum.com/vpostestsv4/shops/shopdemo.jsp?cmd=confirm',
+            'cancelUrl' => 'https://euro.test.modirum.com/vpostestsv4/shops/shopdemo.jsp?cmd=cancel',
         ];
-        $expectedDigest = '2PyXWhzQtfX4tLJEVHKx5C8wnQk=';
+
+        $expectedDigest = 'Xw19+XA5lQXbzEHvvFYe1Zrm7N+rvpdIvzuIyM9HY3Q=';
 
         // Try without a "digest" element.
-        $this->assertEquals($expectedDigest, DigestCalculator::calculate($data, 'xyz'));
+        $this->assertEquals($expectedDigest, DigestCalculator::calculate($data, self::SECRET_KEY));
 
         $data['digest'] = $expectedDigest;
 
         // Try with a "digest" element - should get same answer.
-        $this->assertEquals($expectedDigest, DigestCalculator::calculate($data, 'xyz'));
+        $this->assertEquals($expectedDigest, DigestCalculator::calculate($data, self::SECRET_KEY));
     }
 }


### PR DESCRIPTION
… the example from CardLink documentation